### PR TITLE
Bigger API limits

### DIFF
--- a/kernel/net_memory_operation.h
+++ b/kernel/net_memory_operation.h
@@ -4,9 +4,9 @@
 #include "global.h"
 
 #define API_VERSION 1
-#define MAX_INPUT_BYTES 100
-#define MAX_OUTPUT_BYTES 100
-#define MAX_ABSOLUTE_ADDRESSES 8
+#define MAX_INPUT_BYTES 1000
+#define MAX_OUTPUT_BYTES 1000
+#define MAX_ABSOLUTE_ADDRESSES 16
 #define MINIMUM_MESSAGE_SIZE 4
 
 #pragma pack(push,1)

--- a/kernel/net_memory_operation.h
+++ b/kernel/net_memory_operation.h
@@ -4,8 +4,8 @@
 #include "global.h"
 
 #define API_VERSION 1
-#define MAX_INPUT_BYTES 1000
-#define MAX_OUTPUT_BYTES 1000
+#define MAX_INPUT_BYTES 256
+#define MAX_OUTPUT_BYTES 256
 #define MAX_ABSOLUTE_ADDRESSES 16
 #define MINIMUM_MESSAGE_SIZE 4
 


### PR DESCRIPTION
MAX_INPUT and MAX_OUTPUT are 1 above what can actually be used. 
And 255 is the absolute max defined by the procotol because how many bytes to read/write are encoded into one byte.

The address count also has a max definition of 16 (a nibbble). That one is also a bit of a balance because it can increase the input, but with our current max we don't really need to worry about it.

If you can, please squash lol