### PR TITLE
Align on 32bit reads

### DIFF
--- a/kernel/net_memory_operation.c
+++ b/kernel/net_memory_operation.c
@@ -73,6 +73,11 @@ int processReadCommands(MemoryOperation *memory_op, u8* output) {
     if (op->has_offset) {
       CHECK_INPUT(input_index + 2)
       s32 offset = (s32)((s16) get16FromBuffer(memory_op->data, &input_index));
+      // Pointer addresses are always 32bit aligned (?), so if they aren't, quit out
+      if ((addr & 3) != 0) {
+        return 0;
+      }
+      
       u32 pointer = read32FromGCMemory(addr);
       if (VALID_PTR(pointer)) {
         addr = (u32)((s32)pointer + offset);

--- a/kernel/net_memory_operation.c
+++ b/kernel/net_memory_operation.c
@@ -139,7 +139,8 @@ void write32ToGCMemory(u32 addr, u32 value) {
 
 void readBytesFromGCMemory(u32 addr, int byte_count, u8* output) {
   int index = 0;
-  while (byte_count >= 4) {
+  // Try doing 32bit reads. GCN will crash if addr isn't aligned for them. 
+  while ((byte_count >= 4) && (addr & 3) == 0) {
     u32 result = read32FromGCMemory(addr + index);
     write32ToBuffer(output, result, &index);
     byte_count -= 4;
@@ -173,7 +174,7 @@ void writeBytesToGCMemory(u32 addr, int byte_count, u8* input) {
   u32 current_address = addr & (~3);
   
   if (addr > current_address) {
-    // addr isn't aligned to 32-bit writes, so we need to ignore some of the most significant bytes of thi 32-bit write
+    // addr isn't aligned to 32-bit writes, so we need to ignore some of the most significant bytes of this 32-bit write
     updateAddressWithByteOps(current_address, addr & 3, &bytes_left, input, &input_index);
     current_address += 4;
   }


### PR DESCRIPTION
1. Technically we could probably introduce some more complex logic for normal reading, where if byte_count >= 4, and we are misaligned, we first read normal bytes until we're aligned, then if the byte_count is still >= 4 we do 32bit reads until finally reading back normal bytes. It would be faster, but I also don't particularly care.
2. Question mark on the pointers because i never officially confirmed it and maybe there is a niche situation somewhere where pointer addresses are misaligned